### PR TITLE
Remove .padEnd

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function writeEventsData(events) {
 
 // API
 function listFriends() {
-  var NEW_INDICATOR = "(NEW)     ".padEnd(DATE_DISPLAY_FORMAT);
+  var NEW_INDICATOR = "(NEW)     ";
 
   var events = loadEventsData();
   var friends = loadFriendsData();


### PR DESCRIPTION
We should figure out what interpreters we're targeting / compatibility
issues. We can add this back in, but for now I'm just gonna do the easy
thing and say "This doesn't work on my machine" and rip it out. For now
we don't need the padding anyway, since we have this fixed date format.