### PR TITLE
Add tags to friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ See info about friend:
 $ fl info Kunal
 { name: 'Kunal', interval: 10 }
 ```
+Add and remove tags to friends:
+```
+$ fl tag Kunal running music
+Added 2 new tags to friend Kunal: [running,music]
+$ fl info Kunal
+{ name: 'Kunal', interval: 10, tags: [ 'running', 'music' ] }
+$ fl untag Kunal running
+Removed 1 tags from friend Kunal: [running]
+$ fl info Kunal
+{ name: 'Kunal', interval: 10, tags: [ 'music' ] }
+```
 
 ## Contributing
 Linting is enforced with pre-commit and pre-push hooks. `npm run lint-fix` will help!

--- a/completion.sh
+++ b/completion.sh
@@ -4,8 +4,8 @@ function _fl () {
   local args
   local args_with_names
   COMPREPLY=()
-  args="add list info edit history hangout help"
-  args_with_names="info edit history hangout"
+  args="add list info edit history hangout help tag untag"
+  args_with_names="info edit history hangout tag untag"
   cur=${COMP_WORDS[COMP_CWORD]}
   if [ $COMP_CWORD -eq 1 ]; then
     COMPREPLY=($(compgen -W "$args" -- "$cur"))

--- a/index.js
+++ b/index.js
@@ -236,6 +236,41 @@ function addEvent(friendName, date, memo) {
   console.info("Added event '" + memo + "' on " + isoDate + " with " + friendName);
 }
 
+function addTags(friendName, tags) {
+  var friends = loadFriendsData();
+  var myFriend = getFriendByName(friends, friendName)[0];
+  if (!myFriend) {
+    return ask(
+      "New friend " + friendName + "! Add them to friendlog? [yN]",
+      (answer) => ifYesAddFriend(answer, friendName, () => addTags(friendName, tags))
+    );
+  }
+  myFriend.tags = myFriend.tags || [];
+  var addedTags = _.difference(tags, myFriend.tags);
+  myFriend.tags = myFriend.tags.concat(addedTags);
+  writeFriendsData(friends);
+  console.info("Added " + addedTags.length + " new tags to friend " + friendName
+    + ": [" + addedTags.toString() + "]");
+}
+
+function removeTags(friendName, tags) {
+  var friends = loadFriendsData();
+  var myFriend = getFriendByName(friends, friendName)[0];
+  if (!myFriend) {
+    return ask(
+      "New friend " + friendName + "! Add them to friendlog? [yN]",
+      (answer) => ifYesAddFriend(answer, friendName, () => removeTags(friendName, tags))
+    );
+  }
+  myFriend.tags = myFriend.tags || [];
+  var oldTags = myFriend.tags;
+  myFriend.tags = (argv.a || argv.all) ? [] : _.difference(myFriend.tags, tags);
+  var removedTags = _.difference(oldTags, myFriend.tags);
+  writeFriendsData(friends);
+  console.info("Removed " + removedTags.length + " tags from friend " + friendName
+    + ": [" + removedTags.toString() + "]");
+}
+
 function showHelp() {
   console.log("welcome to friendlog :-)");
   console.log("   add [friend] [interval=10] " + "Adds [friend]. Events expected every [interval] days");
@@ -246,6 +281,8 @@ function showHelp() {
   console.log("   hangout [f] [d] [m]        " + "Records event with [friend] on [date] with [memo]");
   console.log("   history [-c]               " + "See history, grouped by friend or [-chronological]");
   console.log("   history [friend]           " + "See history with specific friend");
+  console.log("   tag [friend] [...tags]     " + "Add any number of [tags] to a friend");
+  console.log("   untag [friend] [...t] [-a] " + "Remove specific [tags] or [-all] tags from a friend");
 }
 
 function showHistory(friendName) {
@@ -287,6 +324,12 @@ function main() {
     showHistory(args[1]);
   } else if (4 === args.length && "hangout" === args[0]) {
     addEvent(args[1], args[2], args[3]);
+  } else if (3 <= args.length && "tag" === args[0]) {
+    addTags(args[1], args.slice(2));
+  } else if (3 <= args.length && "untag" === args[0]) {
+    removeTags(args[1], args.slice(2));
+  } else if (2 === args.length && (argv.a || argv.all)) {
+    removeTags(args[1], args.slice(2));
   } else {
     showHelp();
   }


### PR DESCRIPTION
fixes #50 

see readme change for how to use it.

1. It requires other tickets, perhaps
* "find all friends with tag 'x'". 
* autocomplete on tags?

2. I can change the interface to be `fl tags add` and `fl tags rm`, if you prefer git's style (i.e. `git remote rm/add`). Or it could be related to `fl edit`, with options-args (i.e. tags=blah)
3. I could flesh out `fl tags` showing all tags in system (to use for autocomplete).
4. I could flesh out `fl find tag=running` to find all friends tagged with running.

I worry that we're inventing way too much here -- what's the purpose of this in the first place?


